### PR TITLE
Updating Appium tutorial to use client 2.0.0

### DIFF
--- a/projects/java_android/pom.xml
+++ b/projects/java_android/pom.xml
@@ -19,7 +19,7 @@ https://github.com/appium/appium/blob/2fe7ea7b098ba2145e3c7b4cc31276a3e26921ec/s
     <dependency>
       <groupId>io.appium</groupId>
       <artifactId>java-client</artifactId>
-      <version>1.3.0</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <!-- Must use 1.0.15 or better otherwise upload file will have cookie warnings

--- a/projects/java_android/src/test/java/appium/tutorial/android/AutomatingASimpleActionTest.java
+++ b/projects/java_android/src/test/java/appium/tutorial/android/AutomatingASimpleActionTest.java
@@ -25,7 +25,7 @@ public class AutomatingASimpleActionTest extends AppiumTest {
     @org.junit.Test
     public void three() throws Exception {
         wait(for_text(2)).click();
-        find("Accessibility Node Provider");
+        find("Custom Evaluator");
     }
 
   @org.junit.Test

--- a/projects/java_android/src/test/java/appium/tutorial/android/util/AppiumTest.java
+++ b/projects/java_android/src/test/java/appium/tutorial/android/util/AppiumTest.java
@@ -5,7 +5,7 @@ import com.saucelabs.common.SauceOnDemandAuthentication;
 import com.saucelabs.common.SauceOnDemandSessionIdProvider;
 import com.saucelabs.junit.SauceOnDemandTestWatcher;
 import com.saucelabs.saucerest.SauceREST;
-import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.android.AndroidDriver;
 import org.apache.commons.logging.LogFactory;
 import org.junit.After;
 import org.junit.Before;
@@ -16,12 +16,10 @@ import org.junit.runner.Description;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.DesiredCapabilities;
-import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.io.File;
 import java.net.URL;
 import java.nio.file.Paths;
-import java.text.MessageFormat;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
@@ -101,12 +99,12 @@ public class AppiumTest implements SauceOnDemandSessionIdProvider {
 
             capabilities.setCapability("app", "sauce-storage:" + localApp);
             serverAddress = new URL("http://" + user + ":" + key + "@ondemand.saucelabs.com:80/wd/hub");
-            driver = new AppiumDriver(serverAddress, capabilities);
+            driver = new AndroidDriver(serverAddress, capabilities);
         } else {
             String appPath = Paths.get(userDir, localApp).toAbsolutePath().toString();
             capabilities.setCapability("app", appPath);
             serverAddress = new URL("http://127.0.0.1:4723/wd/hub");
-            driver = new AppiumDriver(serverAddress, capabilities);
+            driver = new AndroidDriver(serverAddress, capabilities);
         }
 
         sessionId = driver.getSessionId().toString();

--- a/projects/java_android/src/test/java/appium/tutorial/android/util/Helpers.java
+++ b/projects/java_android/src/test/java/appium/tutorial/android/util/Helpers.java
@@ -1,54 +1,32 @@
 package appium.tutorial.android.util;
 
-import io.appium.java_client.AppiumDriver;
-import io.appium.java_client.MobileElement;
+import io.appium.java_client.android.AndroidDriver;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.remote.RemoteWebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 
 public abstract class Helpers {
 
-  public static AppiumDriver driver;
+  public static AndroidDriver driver;
   public static URL serverAddress;
   private static WebDriverWait driverWait;
 
   /**
    * Initialize the webdriver. Must be called before using any helper methods. *
    */
-  public static void init(AppiumDriver webDriver, URL driverServerAddress) {
+  public static void init(AndroidDriver webDriver, URL driverServerAddress) {
     driver = webDriver;
     serverAddress = driverServerAddress;
     int timeoutInSeconds = 60;
     // must wait at least 60 seconds for running on Sauce.
     // waiting for 30 seconds works locally however it fails on Sauce.
     driverWait = new WebDriverWait(webDriver, timeoutInSeconds);
-  }
-
-  /**
-   * Wrap WebElement in MobileElement *
-   */
-  private static MobileElement w(WebElement element) {
-    return new MobileElement((RemoteWebElement) element, driver);
-  }
-
-  /**
-   * Wrap WebElement in MobileElement *
-   */
-  private static List<MobileElement> w(List<WebElement> elements) {
-    List list = new ArrayList(elements.size());
-    for (WebElement element : elements) {
-      list.add(w(element));
-    }
-
-    return list;
   }
 
   /**
@@ -61,15 +39,15 @@ public abstract class Helpers {
   /**
    * Return an element by locator *
    */
-  public static MobileElement element(By locator) {
-    return w(driver.findElement(locator));
+  public static WebElement element(By locator) {
+    return driver.findElement(locator);
   }
 
   /**
    * Return a list of elements by locator *
    */
-  public static List<MobileElement> elements(By locator) {
-    return w(driver.findElements(locator));
+  public static List<WebElement> elements(By locator) {
+    return driver.findElements(locator);
   }
 
   /**
@@ -82,7 +60,7 @@ public abstract class Helpers {
   /**
    * Return a list of elements by tag name *
    */
-  public static List<MobileElement> tags(String tagName) {
+  public static List<WebElement> tags(String tagName) {
     return elements(for_tags(tagName));
   }
 
@@ -96,7 +74,7 @@ public abstract class Helpers {
   /**
    * Return a static text element by xpath index *
    */
-  public static MobileElement s_text(int xpathIndex) {
+  public static WebElement s_text(int xpathIndex) {
     return element(for_text(xpathIndex));
   }
 
@@ -110,7 +88,7 @@ public abstract class Helpers {
   /**
    * Return a static text element that contains text *
    */
-  public static MobileElement text(String text) {
+  public static WebElement text(String text) {
     return element(for_text(text));
   }
 
@@ -124,7 +102,7 @@ public abstract class Helpers {
   /**
    * Return a static text element by exact text *
    */
-  public static MobileElement text_exact(String text) {
+  public static WebElement text_exact(String text) {
     return element(for_text_exact(text));
   }
 
@@ -142,22 +120,22 @@ public abstract class Helpers {
         "\",\"" + value + "\"), \"" + value + "\") or @resource-id=\"" + value + "\"]");
   }
 
-  public static MobileElement find(String value) {
+  public static WebElement find(String value) {
     return element(for_find(value));
   }
 
   /**
    * Wait 30 seconds for locator to find an element *
    */
-  public static MobileElement wait(By locator) {
-    return w(driverWait.until(ExpectedConditions.visibilityOfElementLocated(locator)));
+  public static WebElement wait(By locator) {
+    return driverWait.until(ExpectedConditions.visibilityOfElementLocated(locator));
   }
 
   /**
    * Wait 60 seconds for locator to find all elements *
    */
-  public static List<MobileElement> waitAll(By locator) {
-    return w(driverWait.until(ExpectedConditions.visibilityOfAllElementsLocatedBy(locator)));
+  public static List<WebElement> waitAll(By locator) {
+    return driverWait.until(ExpectedConditions.visibilityOfAllElementsLocatedBy(locator));
   }
 
   /**
@@ -170,14 +148,14 @@ public abstract class Helpers {
   /**
    * Return an element that contains name or text *
    */
-  public static MobileElement scroll_to(String value) {
+  public static WebElement scroll_to(String value) {
     return driver.scrollTo(value);
   }
 
   /**
    * Return an element that exactly matches name or text *
    */
-  public static MobileElement scroll_to_exact(String value) {
+  public static WebElement scroll_to_exact(String value) {
     return driver.scrollToExact(value);
   }
 }

--- a/projects/java_android/tutorial_android.iml
+++ b/projects/java_android/tutorial_android.iml
@@ -9,53 +9,57 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Maven: io.appium:java-client:1.3.0" level="project" />
-    <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.2.4" level="project" />
-    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-java:2.42.1" level="project" />
-    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-chrome-driver:2.42.1" level="project" />
-    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-remote-driver:2.42.1" level="project" />
+    <orderEntry type="library" name="Maven: io.appium:java-client:2.0.0" level="project" />
+    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-java:2.43.1" level="project" />
+    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-chrome-driver:2.43.1" level="project" />
+    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-remote-driver:2.43.1" level="project" />
     <orderEntry type="library" name="Maven: cglib:cglib-nodep:2.1_3" level="project" />
-    <orderEntry type="library" name="Maven: org.json:json:20090211" level="project" />
-    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-api:2.42.1" level="project" />
-    <orderEntry type="library" name="Maven: com.google.guava:guava:17.0" level="project" />
+    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-api:2.43.1" level="project" />
+    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-htmlunit-driver:2.43.1" level="project" />
+    <orderEntry type="library" name="Maven: net.sourceforge.htmlunit:htmlunit:2.15" level="project" />
+    <orderEntry type="library" name="Maven: xalan:xalan:2.7.1" level="project" />
+    <orderEntry type="library" name="Maven: xalan:serializer:2.7.1" level="project" />
+    <orderEntry type="library" name="Maven: commons-collections:commons-collections:3.2.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.commons:commons-lang3:3.3.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpmime:4.3.3" level="project" />
+    <orderEntry type="library" name="Maven: net.sourceforge.htmlunit:htmlunit-core-js:2.15" level="project" />
+    <orderEntry type="library" name="Maven: xerces:xercesImpl:2.11.0" level="project" />
+    <orderEntry type="library" name="Maven: xml-apis:xml-apis:1.4.01" level="project" />
+    <orderEntry type="library" name="Maven: net.sourceforge.nekohtml:nekohtml:1.9.21" level="project" />
+    <orderEntry type="library" name="Maven: net.sourceforge.cssparser:cssparser:0.9.14" level="project" />
+    <orderEntry type="library" name="Maven: org.w3c.css:sac:1.3" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-websocket:8.1.15.v20140411" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-util:8.1.15.v20140411" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-io:8.1.15.v20140411" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-http:8.1.15.v20140411" level="project" />
+    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-firefox-driver:2.43.1" level="project" />
+    <orderEntry type="library" name="Maven: commons-io:commons-io:2.4" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.commons:commons-exec:1.1" level="project" />
+    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-ie-driver:2.43.1" level="project" />
+    <orderEntry type="library" name="Maven: net.java.dev.jna:jna:3.4.0" level="project" />
+    <orderEntry type="library" name="Maven: net.java.dev.jna:platform:3.4.0" level="project" />
+    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-safari-driver:2.43.1" level="project" />
+    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-support:2.43.1" level="project" />
+    <orderEntry type="library" name="Maven: org.webbitserver:webbit:0.4.15" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty:3.5.5.Final" level="project" />
     <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpclient:4.3.3" level="project" />
     <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.3.2" level="project" />
     <orderEntry type="library" name="Maven: commons-logging:commons-logging:1.1.3" level="project" />
     <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.6" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.commons:commons-exec:1.1" level="project" />
-    <orderEntry type="library" name="Maven: net.java.dev.jna:jna:3.4.0" level="project" />
-    <orderEntry type="library" name="Maven: net.java.dev.jna:platform:3.4.0" level="project" />
-    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-htmlunit-driver:2.42.1" level="project" />
-    <orderEntry type="library" name="Maven: net.sourceforge.htmlunit:htmlunit:2.14" level="project" />
-    <orderEntry type="library" name="Maven: xalan:xalan:2.7.1" level="project" />
-    <orderEntry type="library" name="Maven: xalan:serializer:2.7.1" level="project" />
-    <orderEntry type="library" name="Maven: xml-apis:xml-apis:1.4.01" level="project" />
-    <orderEntry type="library" name="Maven: commons-collections:commons-collections:3.2.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.commons:commons-lang3:3.2.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpmime:4.3.2" level="project" />
-    <orderEntry type="library" name="Maven: net.sourceforge.htmlunit:htmlunit-core-js:2.14" level="project" />
-    <orderEntry type="library" name="Maven: xerces:xercesImpl:2.11.0" level="project" />
-    <orderEntry type="library" name="Maven: net.sourceforge.nekohtml:nekohtml:1.9.20" level="project" />
-    <orderEntry type="library" name="Maven: net.sourceforge.cssparser:cssparser:0.9.13" level="project" />
-    <orderEntry type="library" name="Maven: org.w3c.css:sac:1.3" level="project" />
-    <orderEntry type="library" name="Maven: commons-io:commons-io:2.4" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-websocket:8.1.14.v20131031" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-util:8.1.14.v20131031" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-io:8.1.14.v20131031" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-http:8.1.14.v20131031" level="project" />
-    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-firefox-driver:2.42.1" level="project" />
-    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-ie-driver:2.42.1" level="project" />
-    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-safari-driver:2.42.1" level="project" />
-    <orderEntry type="library" name="Maven: org.webbitserver:webbit:0.4.14" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty:3.5.2.Final" level="project" />
-    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-support:2.42.1" level="project" />
+    <orderEntry type="library" name="Maven: com.google.guava:guava:17.0" level="project" />
+    <orderEntry type="library" name="Maven: cglib:cglib:3.1" level="project" />
+    <orderEntry type="library" name="Maven: org.ow2.asm:asm:4.2" level="project" />
+    <orderEntry type="library" name="Maven: org.reflections:reflections:0.9.8" level="project" />
+    <orderEntry type="library" name="Maven: javassist:javassist:3.12.1.GA" level="project" />
+    <orderEntry type="library" name="Maven: dom4j:dom4j:1.6.1" level="project" />
+    <orderEntry type="library" name="Maven: com.saucelabs:saucerest:1.0.16" level="project" />
+    <orderEntry type="library" name="Maven: org.json:json:20090211" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.11" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
-    <orderEntry type="library" name="Maven: com.saucelabs:saucerest:1.0.16" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: com.googlecode.json-simple:json-simple:1.1" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: commons-lang:commons-lang:2.6" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: com.saucelabs:sauce_junit:2.1.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: com.saucelabs:sauce_java_common:2.1.3" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.2.4" level="project" />
   </component>
 </module>
-


### PR DESCRIPTION
Updating the Java Android example code to use io.appium java-client 2.0.0 and be able to pass tutorial test cases.