### PR TITLE
Update 08_uiautomatorviewer.md

### DIFF
--- a/modules/en/source/appium/02_native_android_automation/02_appium_ruby_console/08_uiautomatorviewer.md
+++ b/modules/en/source/appium/02_native_android_automation/02_appium_ruby_console/08_uiautomatorviewer.md
@@ -5,11 +5,7 @@ uiautomator requires API 16 (Android 4.1, Jelly Bean) or above. Appium's
 uiautomator support works best on API 17 (Android 4.2,
 Jelly Bean MR1) or above. For this tutorial, we're interested in API 19.
 
-Run `android avd`, select your Android emulator, press Edit, then ensure that
-'Use Host GPU' is not checked. If we're using the Host GPU then uiautomatorviewer
-will be unable to capture screenshots.
-
-Also ensure that no Android appium sessions are running. Appium uses uiautomator
+Ensure that no Android appium sessions are running. Appium uses uiautomator
 internally and this will prevent uiautomatorviewer from working if they're both
 running at the same time.
 
@@ -18,6 +14,3 @@ Manually launch the Api Demos activity on the emulator then click
 with a red circle. The following is a screenshot of the end result:
 
 ![](/common/uiautomatorviewer.png)
-
-Once you're done with uiautomatorviewer, you may want to restore the Host GPU
-option. The Android emulator is significantly faster with it enabled.


### PR DESCRIPTION
Disabling 'Use Host GPU' prevented the Android Emulator from loading for me (OS X Yosemite, Android SDK 19). Re-enabling it allowed me to continue and uiautomatorviewer still captured the screenshots correctly.